### PR TITLE
Refactor updating the centroids

### DIFF
--- a/src/MRI2FE/models/femodel.py
+++ b/src/MRI2FE/models/femodel.py
@@ -257,31 +257,21 @@ class FEModel:
     def update_centroids(self):
         """Update the centroid table with all elements in the element table."""
         if self.element_table.size > 0:
-            # Create a dictionary for O(1) node ID lookup - only once
             node_dict = {
                 int(self.node_table[i, 0]): i
                 for i in range(len(self.node_table))
             }
-
-            # Initialize centroids array
             n_elements = len(self.element_table)
             centroids = np.zeros((n_elements, 3))
 
-            # Process each element efficiently
             for i, element in enumerate(self.element_table):
-                # Extract unique node IDs (skip EID and PID)
                 node_ids = np.unique(element[2:])
-
-                # Get node indices using the pre-computed dictionary
                 node_indices = [
                     node_dict[int(node_id)] for node_id in node_ids
                 ]
-
-                # Calculate centroid
                 centroids[i] = np.mean(
                     self.node_table[node_indices, 1:], axis=0
                 )
-
             self.centroid_table = centroids
 
     def add_part(self, part_id: int, name: str, material_constants: list):

--- a/src/MRI2FE/models/femodel.py
+++ b/src/MRI2FE/models/femodel.py
@@ -1,6 +1,5 @@
 import numpy as np
 from typing import List, Union, Literal
-from ..utilities import element_centroids
 import meshio
 
 
@@ -258,13 +257,32 @@ class FEModel:
     def update_centroids(self):
         """Update the centroid table with all elements in the element table."""
         if self.element_table.size > 0:
-            self.centroid_table = np.apply_along_axis(
-                element_centroids,
-                1,
-                np.array(np.atleast_2d(self.element_table)),
-                np.array(np.atleast_2d(self.node_table)),
-            )
-            self.centroid_table = self.centroid_table
+            # Create a dictionary for O(1) node ID lookup - only once
+            node_dict = {
+                int(self.node_table[i, 0]): i
+                for i in range(len(self.node_table))
+            }
+
+            # Initialize centroids array
+            n_elements = len(self.element_table)
+            centroids = np.zeros((n_elements, 3))
+
+            # Process each element efficiently
+            for i, element in enumerate(self.element_table):
+                # Extract unique node IDs (skip EID and PID)
+                node_ids = np.unique(element[2:])
+
+                # Get node indices using the pre-computed dictionary
+                node_indices = [
+                    node_dict[int(node_id)] for node_id in node_ids
+                ]
+
+                # Calculate centroid
+                centroids[i] = np.mean(
+                    self.node_table[node_indices, 1:], axis=0
+                )
+
+            self.centroid_table = centroids
 
     def add_part(self, part_id: int, name: str, material_constants: list):
         """Add part information (e.g., material constants)."""

--- a/src/MRI2FE/utilities.py
+++ b/src/MRI2FE/utilities.py
@@ -316,10 +316,15 @@ def element_centroids(
 
     elnodes = np.asarray(elnodes)
 
-    nodes = np.unique(elnodes[2:])
+    # Extract unique node IDs from the element (skip EID and PID)
+    node_ids = np.unique(elnodes[2:])
 
-    mask = np.isin(node_coords[:, 0], nodes)
+    # Use optimized boolean indexing - create mask directly
+    mask = np.zeros(len(node_coords), dtype=bool)
+    for node_id in node_ids:
+        mask |= node_coords[:, 0] == node_id
 
+    # Calculate centroid from the masked coordinates
     cx = np.mean(node_coords[mask, 1:], axis=0)
 
     return cx.tolist()

--- a/src/MRI2FE/utilities.py
+++ b/src/MRI2FE/utilities.py
@@ -316,15 +316,11 @@ def element_centroids(
 
     elnodes = np.asarray(elnodes)
 
-    # Extract unique node IDs from the element (skip EID and PID)
     node_ids = np.unique(elnodes[2:])
-
-    # Use optimized boolean indexing - create mask directly
     mask = np.zeros(len(node_coords), dtype=bool)
     for node_id in node_ids:
         mask |= node_coords[:, 0] == node_id
 
-    # Calculate centroid from the masked coordinates
     cx = np.mean(node_coords[mask, 1:], axis=0)
 
     return cx.tolist()


### PR DESCRIPTION
PR for issue  [#44](https://github.com/turnerjennings/MRI2FE/issues/44)
The main idea of changes that I made was to create a node dictionary for an O(1) lookup time and efficiently enumerate through the element table to set the centroids. Additionally, in the utilities file, I am creating a boolean mask which will more effectively determine which nodes are matches. As the number of nodes scales, this should significantly reduce some of the computational time that the function takes.